### PR TITLE
Fix ordering of the `/allTags` page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,7 +79,7 @@ module.exports = (function(eleventyConfig) {
               item.data.tags.map( tag => tagsSet.add(tag))
           }
       });
-      const sortedSet = new Set(Array.from(tagsSet).sort());
+      const sortedSet = new Set(Array.from(tagsSet).sort((str1,str2) => str1.toLowerCase().localeCompare(str2.toLowerCase())));
       return sortedSet;
   });
     // set nunjucks as markdown template engine


### PR DESCRIPTION
This PR introduces the following change:
- Use a natural sorting comparator so that capitalization doesn’t impact the ordering of the tags, making them easier to find when looking at the list.